### PR TITLE
Add E2E-based breaking change detection via CI

### DIFF
--- a/.github/workflows/e2e-breaking-check.yml
+++ b/.github/workflows/e2e-breaking-check.yml
@@ -1,0 +1,90 @@
+name: E2E Breaking Change Check
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: 'integration-lock'
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  e2e-breaking-check:
+    name: e2e-breaking-check
+    runs-on: ubuntu-latest
+    # Reordered condition and restricted to main repository for secret access
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install rust
+        run: |
+          URL="https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.2/rustup-init.sh"
+          EXPECTED_HASH="17247e4bcacf6027ec2e11c79a72c494c9af69ac8d1abcc1b271fa4375a106c2"
+          curl -sSfL "$URL" -o rustup-init.sh
+          echo "$EXPECTED_HASH rustup-init.sh" | sha256sum -c -
+          sh rustup-init.sh -y
+
+      - name: Install wasm-pack
+        env:
+          VERSION: v0.13.1
+        run: |
+          URL="https://raw.githubusercontent.com/drager/wasm-pack/refs/tags/v0.13.1/docs/_installer/init.sh"
+          EXPECTED_HASH="3e91ccfb5ca63dfd6761a3b7acbf6aca04be365e900468888e6615e79528a7cc"
+          curl -sSfL "$URL" -o wasm-pack-init.sh
+          echo "$EXPECTED_HASH wasm-pack-init.sh" | sha256sum -c -
+          sh wasm-pack-init.sh -y
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate integration ENV
+        env:
+          GH_TOKEN: ${{ secrets.IDENTUS_CI }}
+          RUN_ID: ${{ github.run_id }}
+          COMPONENT: sdk-ts
+          CLOUD_SERVICE_TOKEN: ${{ secrets.CLOUD_SERVICE_TOKEN }}
+          CLOUD_SERVICE_URL: ${{ vars.CLOUD_SERVICE_URL || secrets.CLOUD_SERVICE_URL }}
+          CLOUD_SERVICE_TEMPLATE_ID: ${{ vars.CLOUD_SERVICE_TEMPLATE_ID || secrets.CLOUD_SERVICE_TEMPLATE_ID }}
+        run: |
+          npm run environment
+          ENV_VALUE=$(cat env)
+          if [ -z "$ENV_VALUE" ]; then
+            echo "npm run environment did not produce ENV" >&2
+            exit 1
+          fi
+          {
+            echo "ENV<<EOF"
+            echo "$ENV_VALUE"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Run E2E Tests
+        env:
+          ENV: ${{ env.ENV }}
+        run: npm run integration -- --runner sdk-ts

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ In order to test all latest components there's a weekly job.
 
 When there's an expected breaking change the components will have to be compatible before making a final release. That means the `latest` test should be `green`.
 
+E2E tests are executed in CI to detect potential breaking changes in pull requests.
+
 ## Integration
 
 ### Service integration


### PR DESCRIPTION
 Summary
This PR introduces a simple breaking change detection mechanism by running the existing E2E integration tests in CI.

 What’s changed

1. Added a GitHub Actions workflow to run integration tests on pull requests and pushes to main
2. Uses the existing `npm run integration` command as the source of truth for E2E validation
3. The workflow fails if integration tests fail, helping catch potential breaking changes early
4. Added a short note in the README about E2E-based breaking change detection

 Why this approach
Instead of introducing additional tooling, this relies on the current integration test setup as a practical signal for breaking changes, which keeps the solution simple and aligned with how the project is already tested.

 Notes

1. The workflow currently uses the `sdk-ts` runner, aligned with the existing CI setup for Linux environments
2. Other SDK runners (swift, kmp) may require platform-specific setups or are not part of the current CI flow, so they are not included here