### PR TITLE
chore: add standardized branch protection baseline and rollout guide

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,42 @@
+{
+  "name": "Standard Main Branch Protection",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "hyperledger-identus/template",
+  "enforcement": "evaluate",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main",
+        "refs/heads/master"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 2,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": []
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,9 +211,18 @@ See `tests/` directory for examples:
    - Include testing instructions if applicable
 
 3. **Code Review**
-   - Address review comments promptly
-   - Keep PRs focused and reasonably sized
-   - Respond to feedback constructively
+   - **Review Frequency**
+     - Address review comments promptly
+     - Keep PRs focused and reasonably sized
+     - Respond to feedback constructively
+
+### Branch Security
+
+To maintain SDLC stability, all pull requests must adhere to the standardized [Branch Protection Rules](docs/branch-protection.md). Key requirements include:
+- Mandatory peer review (2 approvals).
+- Passing all required status checks (CI, Lint, Unit Tests).
+- Prefer rebase or squash merges where practical to keep history easier to follow.
+- Resolution of all review comments.
 
 ### Commit Messages
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,75 @@
+# Branch Protection and Rulesets
+
+## Purpose
+This document defines the standardized branch protection rules and GitHub rulesets for the Hyperledger Identus ecosystem. Consistent rules ensure SDLC stability, security, and a unified development experience across all repositories.
+
+## Scope
+The rules defined here serve as the baseline for the default branch (`main` or `master`) across the following repositories:
+- cloud-agent
+- mediator
+- sdk-ts
+- sdk-swift
+- sdk-kmp
+- apollo
+- prism-node
+
+## Expected Outcomes
+Implementation of these rules yields the following measurable improvements:
+- **Reduces accidental direct pushes**: Prevents unreviewed code from entering stable branches.
+- **Improves CI reliability**: Ensures all code passes automated tests before merging.
+- **Enforces review discipline**: Guarantees a "four-eyes" principle for every change.
+
+## Standardized Rules
+
+### Pull Request Requirements
+- **Require a pull request before merging**: No direct pushes allowed.
+- **Required Approvals**: **Strict minimum of 2 approvals** from designated maintainers or code owners.
+- **Dismiss stale approvals**: Reviews are automatically dismissed when new commits are pushed.
+- **Require conversation resolution**: All review comments must be resolved before merging.
+
+### Status Checks
+The following logic applies to status checks:
+- **Strict Requirement**: Branches **must** be up to date with the default branch before merging.
+- **Context Naming**: Use repository-specific CI check names (e.g., `CI / build`, `Lint`, `Test`). 
+- **Minimum Checks**: Every repository MUST require at least:
+  - CI Build/Compilation
+  - Linting/Static Analysis
+  - Unit Tests
+  - Integration/E2E Tests (where available)
+
+> [!CAUTION]
+> **Fallback Safety**: Ensure that all required status checks are actually configured and running in the repository’s CI workflows *before* enabling enforcement. If a check is listed but doesn't exist, all PR merges will be blocked.
+
+### Branch Maintenance
+- **Restrict Force Pushes**: (Enforced) No history rewriting on protected branches.
+- **Restrict Deletion**: (Enforced) No deletion of the default branch.
+
+## Application & Rollout Strategy
+
+### Phased Rollout
+Maintainers should avoid a "big bang" rollout across all repositories simultaneously. Recommended path:
+1. **Phase 1 (Pilot)**: Apply to a low-risk or actively maintained repository (e.g., `sdk-ts`) in **Evaluate** mode to monitor impact without blocking workflows.
+2. **Phase 2 (Validation)**: Switch to **Active** mode on the pilot repository and validate CI compatibility.
+3. **Phase 3 (Expansion)**: Gradually apply to other SDKs and core components (`cloud-agent`, `mediator`).
+
+### Enforcement Modes
+- **Evaluate**: Rules are checked, and results are reported in the PR, but merging is not blocked. Use this for testing new rules.
+- **Active**: Rules are strictly enforced.
+
+## Exception Handling & Emergency Scenarios
+In extreme cases (e.g., critical security hotfixes or broken CI blocking urgent releases), the following protocols apply:
+
+- **Admin Bypass**: Organization owners and repository admins can be added to the "Bypass list" in the Ruleset configuration.
+  - **Restriction**: Use **sparingly** and only for verified emergencies.
+  - **Audit**: Every bypass merge should be followed by a **post-merge review** to ensure technical correctness.
+- **Temporary Relaxation**: If a systemic CI issue occurs, a Ruleset can be temporarily set to **Evaluate** mode or internally adjusted by authorized maintainers.
+
+## Application Guide (How to Apply)
+This repository includes a baseline configuration template in [main-branch-protection.json](../.github/rulesets/main-branch-protection.json).
+
+### To apply to a new repository:
+1. Go to **Settings** > **Rules** > **Rulesets**.
+2. Click **New ruleset** > **Import ruleset**.
+3. Upload the `main-branch-protection.json` file.
+4. **Important**: Update the `required_status_checks` list in the UI to match the exact names of the CI workflows in that specific repository.
+5. Set enforcement to **Evaluate** (initially) or **Active**.


### PR DESCRIPTION
This PR introduces a consistent baseline for branch protection across Identus repositories, along with a practical rollout approach.

While going through the issue, I noticed that branch protection rules vary across repositories, which can make the development workflow inconsistent and sometimes risky. The aim here is to define a simple, reusable standard that can be applied gradually without disrupting existing CI setups.

 What’s included

A reusable GitHub Ruleset template for main branches covering:

1.    Required pull requests with 2 approvals
2.    Mandatory status checks (aligned with each repo’s existing CI workflows)
3.    Conversation resolution before merge
4.    Up-to-date branch requirement
5.    Disabled force pushes and branch deletion

A `branch-protection.md` guide that explains:

1.   Why these rules are important for SDLC stability
2.   How to apply the ruleset using GitHub UI (import flow)
3.   How to map required checks to repo-specific CI workflows
4.   A phased rollout strategy (evaluate → active)
5.   Emergency handling (admin bypass with post-merge review)

Rollout approach

Instead of enforcing everything at once, the idea is to:

1.  Start with a low-risk or actively maintained repository in evaluate mode
2.  Validate CI compatibility and required checks
3.  Gradually move to active enforcement and expand to other repositories

Notes

1. This acts as a baseline template, not a hard enforcement — maintainers can adapt it as needed
2. CI check names are intentionally not hardcoded to avoid breaking existing pipelines
3. Admin bypass is documented for emergency use only, with a recommendation for post-merge review

Expected outcome

1. More consistent and predictable merge process across repositories
2. Reduced risk of unreviewed or direct changes to main branches
3. Better confidence in CI before code is merged

