### PR TITLE
chore: fix preexisting yamllint + markdownlint errors on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,3 @@ jobs:
 
       - name: Run tests
         run: npm test
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,6 @@
 Please do not report security vulnerabilities through public GitHub issues.
 
 Instead, report them via:
-https://github.com/hyperledger-identus/integration/security/advisories/new
+<https://github.com/hyperledger-identus/integration/security/advisories/new>
 
 Provide clear steps to reproduce and impact details.


### PR DESCRIPTION
## Why

The **File Hygiene** workflow (reusable `hyperledger-identus/.github` `lint-files` job) has been **failing on `main`** for both YAML and Markdown lints. This blocks every dependent PR that runs these checks — e.g. #149 (which only adds a workflow file) — even when the PR's own changes are clean.

`main`'s most recent File Hygiene run is `failure` (head `116adf5`), and the two offenders are unrelated to any single PR:

| File | Check | Rule | Problem |
|------|-------|------|---------|
| `.github/workflows/ci.yml:39` | yamllint | `empty-lines` (`max-end: 0`) | trailing blank line at EOF |
| `SECURITY.md:8` | markdownlint | `MD034/no-bare-urls` | bare URL |

## What

Two minimal, no-behavior-change fixes:

- **`ci.yml`** — drop the single trailing blank line (file now ends with one newline).
- **`SECURITY.md`** — wrap the bare URL in `<...>` (renders identically, satisfies MD034).

## Verification

Validated locally with the **exact tools and versions** CI uses:
- `yamllint 1.37.1` with the repo's `.yamllint.yml` → `ci.yml` clean (rc=0)
- `markdownlint-cli2 v0.22.1` / `markdownlint v0.40.0` → `SECURITY.md` 0 errors

Diff is exactly 2 files (+1/−2), no other changes.

## Scope

Intentionally a separate, focused PR — this is repo-wide lint hygiene, independent of #149. Once this merges to `main`, the File Hygiene checks on #149 (and any other open PR) go green.
